### PR TITLE
Refactor/method name/validations

### DIFF
--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::PostersController < ApplicationController
   def index
-    posters = Poster.filter_by_params(
+    posters = Poster.apply_params(
       sort: params[:sort]
     )
     render json: PosterSerializer.new(posters, { meta: { count: posters.size}})

--- a/app/models/poster.rb
+++ b/app/models/poster.rb
@@ -4,7 +4,7 @@ class Poster < ApplicationRecord
   validates :year, numericality: { only_integer: true }
   validates :vintage, inclusion: { in: [true, false] }
 
-  def self.filter_by_params(params = {})
+  def self.apply_params(params = {})
     posters = all
     posters = posters.order(created_at: (params[:sort] == "desc" ? :desc : :asc)) if params[:sort].present?
     posters

--- a/spec/models/poster_spec.rb
+++ b/spec/models/poster_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Poster, type: :model do
     it { should validate_inclusion_of(:vintage).in_array([true, false]) }
   end
 
-  describe "The filter_by_params Class Method" do
+  describe "The apply_params Class Method" do
     before(:each) do
       Poster.destroy_all
   
@@ -48,12 +48,12 @@ RSpec.describe Poster, type: :model do
     end
 
     it "can return posters sorted by ascending order" do
-      result = Poster.filter_by_params(sort: 'asc')
+      result = Poster.apply_params(sort: 'asc')
       expect(result).to eq([@poster_1, @poster_2, @poster_3])
     end
 
-    it "can return poster sorted by descending order" do
-      result = Poster.filter_by_params(sort: 'desc')
+    it "can return posters sorted by descending order" do
+      result = Poster.apply_params(sort: 'desc')
       expect(result).to eq([@poster_3, @poster_2, @poster_1])
     end
   end

--- a/spec/models/poster_spec.rb
+++ b/spec/models/poster_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Poster, type: :model do
     it { should validate_presence_of(:img_url) }
     it { should validate_numericality_of(:price).is_greater_than(0) }
     it { should validate_numericality_of(:year).only_integer }
-    it { should validate_inclusion_of(:vintage).in_array([true, false]) }
+    it { should allow_value(true).for(:vintage) }
+    it { should allow_value(false).for(:vintage) }
   end
 
   describe "The apply_params Class Method" do


### PR DESCRIPTION
Refactored method name from `filter_by_params` to `apply_params` to be more inclusive for adding additional params.

Refactored validations in model for `:vintage`
This credit goes to Terra as this was to prevent a merge conflict.
